### PR TITLE
Devise updated to version 1.4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This will *only* work for Rails 3 applications.
 
 In the Gemfile for your application:
 
-    gem "devise", "1.4.0"
+    gem "devise", "1.4.2"
     gem "devise_ldap_authenticatable"
     
 To get the latest version, pull directly from github instead of the gem:

--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -119,14 +119,14 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<devise>, ["= 1.4.0"])
+      s.add_runtime_dependency(%q<devise>, ["= 1.4.2"])
       s.add_runtime_dependency(%q<net-ldap>, ["= 0.2.2"])
     else
-      s.add_dependency(%q<devise>, ["= 1.4.0"])
+      s.add_dependency(%q<devise>, ["= 1.4.2"])
       s.add_dependency(%q<net-ldap>, ["= 0.2.2"])
     end
   else
-    s.add_dependency(%q<devise>, ["= 1.4.0"])
+    s.add_dependency(%q<devise>, ["= 1.4.2"])
     s.add_dependency(%q<net-ldap>, ["= 0.2.2"])
   end
 end


### PR DESCRIPTION
Hi guys,

Could you update devise dependency to 1.4.2? There is no version 1.4.0 anymore on rubgems.

Thanks!
