### PR TITLE
Group membership check for nested Active Directory groups

### DIFF
--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -34,6 +34,9 @@ module Devise
   
   mattr_accessor :ldap_auth_username_builder
   @@ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "#{attribute}=#{login},#{ldap.base}" }
+
+  mattr_accessor :ldap_ad_group_check
+  @@ldap_ad_group_check = false
 end
 
 # Add ldap_authenticatable strategy to defaults.

--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -130,14 +130,27 @@ module Devise
             group_attribute = "uniqueMember"
             group_name = group
           end
-          admin_ldap.search(:base => group_name, :scope => Net::LDAP::SearchScope_BaseObject) do |entry|
-            unless entry[group_attribute].include? dn
+          unless ::Devise.ldap_ad_group_check
+            admin_ldap.search(:base => group_name, :scope => Net::LDAP::SearchScope_BaseObject) do |entry|
+              unless entry[group_attribute].include? dn
+                DeviseLdapAuthenticatable::Logger.send("User #{dn} is not in group: #{group_name }")
+                return false
+              end
+            end
+          else
+            # AD optimization - extension will recursively check sub-groups with one query
+            # "(memberof:1.2.840.113556.1.4.1941:=group_name)"
+            search_result = admin_ldap.search(:base => dn, 
+                              :filter => Net::LDAP::Filter.ex("memberof:1.2.840.113556.1.4.1941", group_name),
+                              :scope => Net::LDAP::SearchScope_BaseObject) 
+            # Will return  the user entry if belongs to group otherwise nothing
+            unless search_result.length == 1 && search_result[0].dn.eql?(dn)
               DeviseLdapAuthenticatable::Logger.send("User #{dn} is not in group: #{group_name }")
               return false
             end
           end
         end
-        
+ 
         return true
       end
       

--- a/lib/generators/devise_ldap_authenticatable/install_generator.rb
+++ b/lib/generators/devise_ldap_authenticatable/install_generator.rb
@@ -36,6 +36,7 @@ module DeviseLdapAuthenticatable
   # config.ldap_check_group_membership = false
   # config.ldap_check_attributes = false
   # config.ldap_use_admin_to_bind = false
+  # config.ldap_ad_group_check = false
   
       eof
       if options.advanced?  


### PR DESCRIPTION
Added an option to use Active Directory match filter for the group membership check.

Useful for efficiently checking group membership against Active Directory server groups that have nested groups within them.
