### PR TITLE
Return array values with get_ldap_param

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -101,6 +101,7 @@ module Devise
             DeviseLdapAuthenticatable::Logger.send("Requested param #{param} has value #{ldap_entry.send(param)}")
             value = ldap_entry.send(param)
             value = value.first if value.is_a?(Array) and value.count == 1
+            value
           else
             DeviseLdapAuthenticatable::Logger.send("Requested param #{param} does not exist")
             value = nil


### PR DESCRIPTION
Currently if multiple values exist for an attribute in ldap get_ldap_param returns nil.  This changes this to return the array of values
