### PR TITLE
Support HTTP-basic-authentication as well as params-authentication.

### DIFF
--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -9,7 +9,7 @@ module Devise
       # success and the authenticated user if everything is okay. Otherwise redirect
       # to sign in page.
       def authenticate!
-        resource = valid_password? && mapping.to.authenticate_with_ldap(params[scope])
+        resource = valid_password? && mapping.to.authenticate_with_ldap(authentication_hash.merge(:password => password))
         if validate(resource)
           success!(resource)
         else


### PR DESCRIPTION
Hi. I added support for HTTP-basic authentication with this strategy. The old way of selecting the data directly from the params object is replaced with the devise-supplied authentication hash.
