### PR TITLE
Update ldap without service accounts

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -24,6 +24,10 @@ module Devise
       resource.change_password! if new_password.present?
     end
 
+    def self.update_own_password(login, new_password, current_password)
+      set_ldap_param(login, :userpassword, new_password, current_password)
+    end
+
     def self.ldap_connect(login)
       options = {:login => login,
                  :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
@@ -42,6 +46,15 @@ module Devise
 
     def self.get_dn(login)
       self.ldap_connect(login).dn
+    end
+
+    def self.set_ldap_param(login, param, new_value, password = nil)
+      options = { :login => login,
+                  :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                  :password => password }
+
+      resource = LdapConnect.new(options)
+      resource.set_param(param, new_value)
     end
 
     def self.get_ldap_param(login,param)
@@ -79,6 +92,10 @@ module Devise
         @login = params[:login]
         @password = params[:password]
         @new_password = params[:new_password]
+      end
+
+      def set_param(param, new_value)
+        update_ldap( { param.to_sym => new_value } )
       end
 
       def dn
@@ -237,10 +254,15 @@ module Devise
           operations = ops
         end
 
-        admin_ldap = LdapConnect.admin
+        if ::Devise.ldap_use_admin_to_bind
+          privileged_ldap = LdapConnect.admin
+        else
+          authenticate!
+          privileged_ldap = self.ldap
+        end
 
         DeviseLdapAuthenticatable::Logger.send("Modifying user #{dn}")
-        admin_ldap.modify(:dn => dn, :operations => operations)
+        privileged_ldap.modify(:dn => dn, :operations => operations)
       end
 
     end

--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -22,6 +22,12 @@ module Devise
         self[@login_with]
       end
 
+      def change_password!(current_password)
+        raise "Need to set new password first" if @password.blank?
+
+        Devise::LdapAdapter.update_own_password(login_with, @password, current_password)
+      end
+      
       def reset_password!(new_password, new_password_confirmation)
         if new_password == new_password_confirmation && ::Devise.ldap_update_password
           Devise::LdapAdapter.update_password(login_with, new_password)


### PR DESCRIPTION
Hi CSchiewek,

I'm working in a project where users are allowed to update their own passwords and mail-forwarding-addresses, but using a service account for this would be a bit much - for starters, dealing out credentials for service accounts that have sufficient privileges to update the passwords of other users is a bad idea if it is not absolutely required to do so. 

I realize that this is required to be able to use Recoverable, but seeing as how we do not need Recoverable, but _do_ need to update the password, I created a patch that allows such things. If you think it's useful, go ahead and integrate. 

The bad part: I was unable to get the test suite to work as-is. It has some outdated dependencies and I try as I might, I could not find a configuration of Bundler / Rails / Test::Unit / ffi / Capybara that would actually run the tests without crashing. if you have a more up-to-date Gemfile / Gemfile.lock combination for the test/rails_app, I would be happy to oblige.
