### PR TITLE
Add support for fallback hosts

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -67,6 +67,23 @@ module Devise
         @ldap.host = ldap_config["host"]
         @ldap.port = ldap_config["port"]
         @ldap.base = ldap_config["base"]
+
+        # try all servers and get one responding
+        if ldap_config["hosts"]
+          servers = ldap_config["hosts"].split(',')
+          servers.each do |host|
+            begin
+              @ldap.host = host
+              @ldap.open do end
+            rescue Net::LDAP::LdapError
+              DeviseLdapAuthenticatable::Logger.send("Could not connect to #{@ldap.host}, trying next one")
+              next
+            else
+              break
+            end
+          end
+        end
+
         @attribute = ldap_config["attribute"]
         @ldap_auth_username_builder = params[:ldap_auth_username_builder]
         

--- a/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
+++ b/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
@@ -22,6 +22,8 @@ authorizations: &AUTHORIZATIONS
 
 development:
   host: localhost
+  ## Uncommented, this will precede the previous host and introduce fallback hosts. They are tried in specified order.
+  #hosts: host1,host2,host3
   port: 389
   attribute: cn
   base: ou=people,dc=test,dc=com
@@ -32,6 +34,8 @@ development:
 
 test:
   host: localhost
+  ## Uncommented, this will precede the previous host and introduce fallback hosts. They are tried in specified order.
+  #hosts: host1,host2,host3
   port: 3389
   attribute: cn
   base: ou=people,dc=test,dc=com
@@ -42,6 +46,8 @@ test:
 
 production:
   host: localhost
+  ## Uncommented, this will precede the previous host and introduce fallback hosts. They are tried in specified order.
+  #hosts: host1,host2,host3
   port: 636
   attribute: cn
   base: ou=people,dc=test,dc=com


### PR DESCRIPTION
We've been using an LDAP fallback at work so I added this optional config entry that introduces the feature.

I'd be happy with any feedback on implementation and such.
