### PR TITLE
Fix: can't login when login or dn is in UTF-8

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -111,7 +111,6 @@ module Devise
       end
 
       def dn
-        DeviseLdapAuthenticatable::Logger.send("TEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEST")
         DeviseLdapAuthenticatable::Logger.send("LDAP dn lookup: #{@attribute}=#{@login}")
         ldap_entry = search_for_login
         bin_dn = if ldap_entry.nil?


### PR DESCRIPTION
I wrote simple patch to fix issue, when some data (login or dn) is in UTF-8.
Without this patch you won't be able to login in this case.

For example I had situation when devise_ldap_authenticatable tried and failed with `cn=graudējs,dc=example,dc=com` or `cn=graudeejs,ou=piemērs,dc=example,dc=com`

To avoid problems you need to force BINARY encoding for data that you send to ldap
