### PR TITLE
Make deleting LDAP parameters possible

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -57,6 +57,15 @@ module Devise
       resource.set_param(param, new_value)
     end
 
+    def self.delete_ldap_param(login, param, password = nil)
+      options = { :login => login,
+                  :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                  :password => password }
+
+      resource = LdapConnect.new(options)
+      resource.delete_param(param)
+    end
+
     def self.get_ldap_param(login,param)
       resource = self.ldap_connect(login)
       resource.ldap_param_value(param)
@@ -92,6 +101,10 @@ module Devise
         @login = params[:login]
         @password = params[:password]
         @new_password = params[:new_password]
+      end
+
+      def delete_param(param)
+        update_ldap [[:delete, param.to_sym, nil]]
       end
 
       def set_param(param, new_value)


### PR DESCRIPTION
For our LDAP we need to be able to delete LDAP values (in our case, our mailserver doesn't handle empty mailForwardingAddress fields correctly, so we need to delete it if necessary).

This commit adds support for that.

Unfortunately I could not get the tests to work.
