### PR TITLE
Make LdapAdapter#check_group_membership configurable in ldap.yml.

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -84,6 +84,7 @@ module Devise
         @ldap_auth_username_builder = params[:ldap_auth_username_builder]
 
         @group_base = ldap_config["group_base"]
+        @check_group_membership = ldap_config.has_key?("check_group_membership") ? ldap_config["check_group_membership"] : ::Devise.ldap_check_group_membership
         @required_groups = ldap_config["required_groups"]
         @required_attributes = ldap_config["require_attribute"]
 
@@ -148,7 +149,7 @@ module Devise
       end
 
       def in_required_groups?
-        return true unless ::Devise.ldap_check_group_membership
+        return true unless @check_group_membership
 
         ## FIXME set errors here, the ldap.yml isn't set properly.
         return false if @required_groups.nil?

--- a/test/rails_app/config/ldap_with_check_membership_off.yml
+++ b/test/rails_app/config/ldap_with_check_membership_off.yml
@@ -1,0 +1,23 @@
+authorizations: &AUTHORIZATIONS
+  ## Authorization
+  group_base: ou=groups,dc=test,dc=com
+  check_group_membership: false
+  required_groups:
+    - cn=admins,ou=groups,dc=test,dc=com
+    - ["authorizationRole", "cn=users,ou=groups,dc=test,dc=com"]
+  require_attribute:
+    objectClass: inetOrgPerson
+    authorizationRole: blogAdmin
+    
+test: &TEST
+  host: localhost
+  port: 3389
+  attribute: cn
+  base: ou=people,dc=test,dc=com
+  admin_user: cn=admin,dc=test,dc=com
+  admin_password: secret
+  ssl: false
+  <<: *AUTHORIZATIONS
+  
+development:
+  <<: *TEST

--- a/test/rails_app/config/ldap_with_check_membership_on.yml
+++ b/test/rails_app/config/ldap_with_check_membership_on.yml
@@ -1,0 +1,23 @@
+authorizations: &AUTHORIZATIONS
+  ## Authorization
+  group_base: ou=groups,dc=test,dc=com
+  check_group_membership: true
+  required_groups:
+    - cn=admins,ou=groups,dc=test,dc=com
+    - ["authorizationRole", "cn=users,ou=groups,dc=test,dc=com"]
+  require_attribute:
+    objectClass: inetOrgPerson
+    authorizationRole: blogAdmin
+    
+test: &TEST
+  host: localhost
+  port: 3389
+  attribute: cn
+  base: ou=people,dc=test,dc=com
+  admin_user: cn=admin,dc=test,dc=com
+  admin_password: secret
+  ssl: false
+  <<: *AUTHORIZATIONS
+  
+development:
+  <<: *TEST

--- a/test/rails_app/test/unit/user_test.rb
+++ b/test/rails_app/test/unit/user_test.rb
@@ -127,21 +127,56 @@ class UserTest < ActiveSupport::TestCase
         ::Devise.ldap_check_group_membership = true
       end
 
-      should "admin should be allowed in" do
-        should_be_validated @admin, "admin_secret"
+      context "config check_group_membership is not defined" do
+        should "admin should be allowed in" do
+          should_be_validated @admin, "admin_secret"
+        end
+
+        should "admin should have the proper groups set" do
+          assert_contains(@admin.ldap_groups, /cn=admins/, "groups attribute not being set properly")
+        end
+
+        should "user should not be allowed in" do
+          should_not_be_validated @user, "secret"
+        end
+
+        should "not be validated if group with different attribute is removed" do
+          `ldapmodify #{ldap_connect_string} -f ../ldap/delete_authorization_role.ldif`
+          should_not_be_validated @admin, "admin_secret"
+        end
       end
 
-      should "admin should have the proper groups set" do
-        assert_contains(@admin.ldap_groups, /cn=admins/, "groups attribute not being set properly")
-      end
+      context "config file check_group_membership is defined" do
+        setup do
+          default_devise_settings!
+          reset_ldap_server!
+        end
 
-      should "user should not be allowed in" do
-        should_not_be_validated @user, "secret"
-      end
+        context "check_group_membership is turned on" do
+          setup do
+            ::Devise.ldap_config = "#{Rails.root}/config/ldap_with_check_membership_on.yml"
 
-      should "not be validated if group with different attribute is removed" do
-        `ldapmodify #{ldap_connect_string} -f ../ldap/delete_authorization_role.ldif`
-        should_not_be_validated @admin, "admin_secret"
+            ::Devise.ldap_check_group_membership = false
+          end
+
+          # Config file value has precedence over ldap_check_group_membership
+          should "user should not be allowed in" do
+            should_not_be_validated @user, "secret"
+          end
+        end
+
+        context "check_group_membership is turned off" do
+          setup do
+            ::Devise.ldap_config = "#{Rails.root}/config/ldap_with_check_membership_off.yml"
+
+            ::Devise.ldap_check_group_membership = true
+          end
+
+          # Config file value has precedence over ldap_check_group_membership
+          should "user should be allowed in" do
+            should_be_validated @user, "secret"
+          end
+        end
       end
     end
 


### PR DESCRIPTION
Hi. I would like to make ldap_check_group_membership configurable in the yaml file:

We run the same application with different configurations and having that part of the configuration fixed in code is a bit awkward.

This commit adds an option "check_group_membership" to the yaml file that overrides the value of Devise.ldap_check_group_membership.

If the option is not present in the yaml file, behavior is unchanged.
