### PR TITLE
Fixed DEPRECATION Warning on Devise::Strategy

### DIFF
--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -10,10 +10,10 @@ module Devise
       # to sign in page.
       def authenticate!
         resource = valid_password? && mapping.to.authenticate_with_ldap(params[scope])
+        return fail(:invalid) unless resource
+
         if validate(resource)
           success!(resource)
-        else
-          fail(:invalid)
         end
       end
     end


### PR DESCRIPTION
Kept getting this warning because the #validate method was not testing for nil resource.

DEPRECATION WARNING: an empty resource was given to Devise::Strategies::LdapAuthenticatable#validate. Please ensure the resource is not nil. (called from post at /Users/jodegard/.rvm/rubies/ruby-1.9.2-p290/lib/ruby/1.9.1/forwardable.rb:182)

I changed the code in strategy.rb to reflect how it behaves in database_authenticatable and properly test for nil.
