### PR TITLE
Typo spelling fix.

### DIFF
--- a/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
+++ b/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
@@ -1,7 +1,7 @@
 ## Authorizations
-# Uncomment out the merging for each enviornment that you'd like to include.
+# Uncomment out the merging for each environment that you'd like to include.
 # You can also just copy and paste the tree (do not include the "authorizations") to each
-# enviornment if you need something different per enviornment.
+# environment if you need something different per enviornment.
 authorizations: &AUTHORIZATIONS
   group_base: ou=groups,dc=test,dc=com
   ## Requires config.ldap_check_group_membership in devise.rb be true
@@ -18,7 +18,7 @@ authorizations: &AUTHORIZATIONS
     objectClass: inetOrgPerson
     authorizationRole: postsAdmin
 
-## Enviornments
+## Environment
 
 development:
   host: localhost


### PR DESCRIPTION
The word environment was misspelled multiple times.
