### PR TITLE
Allow configuration of group membership lookup attributes

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -75,6 +75,10 @@ module Devise
       self.ldap_connect(login).search_for_login
     end
 
+    def self.get_ldap_attribute(login, attribute_name)
+      self.ldap_connect(login).attribute(attribute_name)
+    end
+
     class LdapConnect
 
       attr_reader :ldap, :login
@@ -242,6 +246,14 @@ module Devise
         end
 
         admin_ldap.search(:filter => filter, :base => @group_base).collect(&:dn)
+      end
+
+      def attribute attribute_name
+        admin_ldap = LdapConnect.admin
+
+        DeviseLdapAuthenticatable::Logger.send("Getting attribute #{attribute_name} for user #{dn}")
+
+        find_ldap_user(admin_ldap)[attribute_name]
       end
 
       def valid_login?

--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -75,10 +75,6 @@ module Devise
       self.ldap_connect(login).search_for_login
     end
 
-    def self.get_ldap_attribute(login, attribute_name)
-      self.ldap_connect(login).attribute(attribute_name)
-    end
-
     class LdapConnect
 
       attr_reader :ldap, :login
@@ -246,14 +242,6 @@ module Devise
         end
 
         admin_ldap.search(:filter => filter, :base => @group_base).collect(&:dn)
-      end
-
-      def attribute attribute_name
-        admin_ldap = LdapConnect.admin
-
-        DeviseLdapAuthenticatable::Logger.send("Getting attribute #{attribute_name} for user #{dn}")
-
-        find_ldap_user(admin_ldap)[attribute_name]
       end
 
       def valid_login?

--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -93,6 +93,14 @@ module Devise
         @ldap_auth_username_builder = params[:ldap_auth_username_builder]
 
         @group_base = ldap_config["group_base"]
+
+        # Check if specific group membership attributes must be used to retrieve the user groups
+        if ldap_config.has_key?("group_member_attributes") and ldap_config["group_member_attributes"].is_a? Array and ldap_config["group_member_attributes"].any?
+          @group_member_attributes = ldap_config["group_member_attributes"].uniq
+        else
+          @group_member_attributes = ["uniqueMember"]
+        end       
+        
         @check_group_membership = ldap_config.has_key?("check_group_membership") ? ldap_config["check_group_membership"] : ::Devise.ldap_check_group_membership
         @required_groups = ldap_config["required_groups"]
         @required_attributes = ldap_config["require_attribute"]
@@ -221,7 +229,18 @@ module Devise
         admin_ldap = LdapConnect.admin
 
         DeviseLdapAuthenticatable::Logger.send("Getting groups for #{dn}")
-        filter = Net::LDAP::Filter.eq("uniqueMember", dn)
+
+        # Retrieve the user to get his attributes
+        user = find_ldap_user(admin_ldap)
+
+        # At least one filter must be present
+        filter = build_group_filter(@group_member_attributes[0], user)
+
+        # From the second element in the group attributes configuration, combinates the filters with an OR operator
+        @group_member_attributes.drop(1).each do |attribute_config|
+          filter = filter | build_group_filter(attribute_config, user)
+        end
+
         admin_ldap.search(:filter => filter, :base => @group_base).collect(&:dn)
       end
 
@@ -279,6 +298,17 @@ module Devise
         privileged_ldap.modify(:dn => dn, :operations => operations)
       end
 
+      def build_group_filter attribute_config, user
+        # Check if the member attribute must use different field on the user than the dn one
+        if attribute_config[':']
+          attribute_parts = attribute_config.split ":"           
+
+          Net::LDAP::Filter.eq(attribute_parts[0], user["#{attribute_parts[1]}"][0])	
+        else
+          Net::LDAP::Filter.eq(attribute_config, dn)	
+        end
+      end
+      
     end
 
   end

--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -62,7 +62,7 @@ module Devise
       end
 
       def ldap_attribute(attribute_name)
-        Devise::LdapAdapter.get_ldap_attribute(login_with, attribute_name)
+        Devise::LdapAdapter.get_ldap_param(login_with, attribute_name)
       end
 
       #

--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -61,6 +61,10 @@ module Devise
         Devise::LdapAdapter.get_ldap_param(login_with,param)
       end
 
+      def ldap_attribute(attribute_name)
+        Devise::LdapAdapter.get_ldap_attribute(login_with, attribute_name)
+      end
+
       #
       # callbacks
       #

--- a/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
+++ b/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
@@ -17,6 +17,15 @@ authorizations: &AUTHORIZATIONS
   require_attribute:
     objectClass: inetOrgPerson
     authorizationRole: postsAdmin
+  ## When defined, the group_member_attributes takes an array where are specified which attributes
+  ## must be looked up to retrieve the user groups when ldap_groups is called on the user model.
+  ## In some cases, a specific use attribute should be used to lookup the group attribute.
+  ## Example: posixGroup linked a user to the group with the uid attribute. Therefore the syntax is 
+  ## something like that: uid=username. In this case, the DN attribute cannot be use. To address this
+  ## issue, the syntax in the configuration is groupMemberAttribute:userAttribute.
+  ## The memberUnique is used by default when the group_member_attributes is not present.
+  ## Finally, you could have some configuration like the following one:
+  group_member_attributes: [ "member", "memberUid:uid", ...]
 
 ## Enviornments
 


### PR DESCRIPTION
In my company, we have several type of group in our LDAP directory. We have for example posixGroup, groupOfUniqueNames or groupOfNames.

Currently, this is not possible to retrieve ALL the groups for a user and therefore, I propose a way to configure how the groups are retrieved with a configuration like that in ldap.yml

```yaml
authorizations: &AUTHORIZATIONS
  group_member_attributes: [ "uniqueMember", "member", "memberUid:uid" ]
```
In this configuration, we can lookup through uniqueMember and member attributes. In the case of posixGroup, the way to lookup is different from a comparison with the DN of the user like for other types. Then, the syntax groupAttributeName:userAttribute is possible to use an attribute directly got from the LDAP user.