### PR TITLE
Fix failing spec and hash password when using update_own_password

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap_adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap_adapter.rb
@@ -25,7 +25,7 @@ module Devise
     end
 
     def self.update_own_password(login, new_password, current_password)
-      set_ldap_param(login, :userpassword, new_password, current_password)
+      set_ldap_param(login, :userpassword, Net::LDAP::Password.generate(:sha, new_password), current_password)
     end
 
     def self.ldap_connect(login)

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -46,7 +46,8 @@ describe 'Users' do
 
       it "should change password" do
         should_be_validated @user, "secret"
-        @user.reset_password!("changed","changed")
+        @user.password = "changed"
+        @user.change_password!("secret")
         should_be_validated @user, "changed", "password was not changed properly on the LDAP sevrer"
       end
 


### PR DESCRIPTION
The design has changed and the current password change test is outdated. This patches the test to use `change_password!` as appropriate. 

In addition the password is saved unhashed when binding as user with `update_own_password`, making the patched test fail. This patch just hashes the password.
