### PR TITLE
allow net-ldap 0.4.x

### DIFF
--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('devise', '3.0.0.rc')
-  s.add_dependency('net-ldap', '~> 0.3.1')
+  s.add_dependency('net-ldap', '>= 0.3.1', '< 0.5.0')
 
   s.add_development_dependency('rake', '>= 0.9')
   s.add_development_dependency('rdoc', '>= 3')


### PR DESCRIPTION
the current release of net-ldap is broken in jruby. specifically, it has some character weirdness in its gemspec which causes it to not install. this issue is fixed in its master branch, but the version has been bumped to 0.4.0.

This commit allows us to use the current net-ldap from github.
