### PR TITLE
Update devise_ldap_authenticatable.gemspec

### DIFF
--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('devise', '>= 3.0')
-  s.add_dependency('net-ldap', '>= 0.3.1', '< 0.5.0')
+  s.add_dependency('net-ldap', '>= 0.3.1', '< 0.6.0')
 
   s.add_development_dependency('rake', '>= 0.9')
   s.add_development_dependency('rdoc', '>= 3')


### PR DESCRIPTION
To work with latest ruby-net-ldap (see https://github.com/ruby-ldap/ruby-net-ldap/commit/bbef82f22494864f5c0e53d4dffb21cead3fc274)
