### PR TITLE
Fixed code example for Querying LDAP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ in your user model:
     before_save :get_ldap_email
 
     def get_ldap_email
-      self.email = Devise::LdapAdapter.get_ldap_param(self.username,"mail")
+      self.email = Devise::LDAP::Adapter.get_ldap_param(self.username,"mail")
     end
 
 Configuration


### PR DESCRIPTION
Hello there,

I did a simple correction for the code sample in the Querying LDAP section. Now we should use `Devise::LDAP::Adapter.get_ldap_param` instead of `Devise::LdapAdapter.get_ldap_param`
