### PR TITLE
Add a backward compatible option to support LDAP user binding

### DIFF
--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -36,6 +36,9 @@ module Devise
 
   mattr_accessor :ldap_ad_group_check
   @@ldap_ad_group_check = false
+
+  mattr_accessor :ldap_anonymous_bind
+  @@ldap_anonymous_bind = true
 end
 
 # Add ldap_authenticatable strategy to defaults.

--- a/lib/devise_ldap_authenticatable/ldap/adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap/adapter.rb
@@ -9,7 +9,8 @@ module Devise
         options = {:login => login,
                    :password => password_plaintext,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :admin => ::Devise.ldap_use_admin_to_bind,
+                   :anonymous_bind => ::Devise.ldap_anonymous_bind}
 
         resource = Devise::LDAP::Connection.new(options)
         resource.authorized?
@@ -19,7 +20,8 @@ module Devise
         options = {:login => login,
                    :new_password => new_password,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :admin => ::Devise.ldap_use_admin_to_bind,
+                   :anonymous_bind => ::Devise.ldap_anonymous_bind}
 
         resource = Devise::LDAP::Connection.new(options)
         resource.change_password! if new_password.present?
@@ -32,7 +34,8 @@ module Devise
       def self.ldap_connect(login)
         options = {:login => login,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :admin => ::Devise.ldap_use_admin_to_bind,
+                   :anonymous_bind => ::Devise.ldap_anonymous_bind}
 
         resource = Devise::LDAP::Connection.new(options)
       end
@@ -56,7 +59,8 @@ module Devise
       def self.set_ldap_param(login, param, new_value, password = nil)
         options = { :login => login,
                     :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                    :password => password }
+                    :password => password,
+                    :anonymous_bind => ::Devise.ldap_anonymous_bind }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.set_param(param, new_value)
@@ -65,7 +69,8 @@ module Devise
       def self.delete_ldap_param(login, param, password = nil)
         options = { :login => login,
                     :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                    :password => password }
+                    :password => password,
+                    :anonymous_bind => ::Devise.ldap_anonymous_bind }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.delete_param(param)

--- a/lib/devise_ldap_authenticatable/ldap/adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap/adapter.rb
@@ -31,10 +31,11 @@ module Devise
         set_ldap_param(login, :userpassword, Net::LDAP::Password.generate(:sha, new_password), current_password)
       end
 
-      def self.ldap_connect(login)
+      def self.ldap_connect(login, password = nil)
         options = {:login => login,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
                    :admin => ::Devise.ldap_use_admin_to_bind,
+                   :password => password,
                    :anonymous_bind => ::Devise.ldap_anonymous_bind}
 
         resource = Devise::LDAP::Connection.new(options)
@@ -76,8 +77,13 @@ module Devise
         resource.delete_param(param)
       end
 
-      def self.get_ldap_param(login,param)
-        resource = self.ldap_connect(login)
+      def self.get_ldap_param(login,param, password = nil)
+        options = { :login => login,
+                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                    :password => password,
+                    :bind_user => ::Devise.ldap_user_to_bind }
+
+        resource = Devise::LDAP::Connection.new(options)
         resource.ldap_param_value(param)
       end
 

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -26,6 +26,11 @@ module Devise
         @login = params[:login]
         @password = params[:password]
         @new_password = params[:new_password]
+
+        if !params[:anonymous_bind]
+          # non anonymous binding requires this
+          @ldap.auth @login, @password
+        end
       end
 
       def delete_param(param)

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -21,14 +21,16 @@ module Devise
         @required_groups = ldap_config["required_groups"]
         @required_attributes = ldap_config["require_attribute"]
 
-        @ldap.auth ldap_config["admin_user"], ldap_config["admin_password"] if params[:admin]
 
         @login = params[:login]
         @password = params[:password]
         @new_password = params[:new_password]
 
-        if !params[:anonymous_bind]
-          # non anonymous binding requires this
+        if params[:admin]
+          @ldap.auth ldap_config["admin_user"], ldap_config["admin_password"]
+
+        elsif !params[:anonymous_bind]
+          # non anonymous binding using the users credentials
           @ldap.auth @login, @password
         end
       end

--- a/lib/generators/devise_ldap_authenticatable/install_generator.rb
+++ b/lib/generators/devise_ldap_authenticatable/install_generator.rb
@@ -37,6 +37,7 @@ module DeviseLdapAuthenticatable
   # config.ldap_check_attributes = false
   # config.ldap_use_admin_to_bind = false
   # config.ldap_ad_group_check = false
+  # config.ldap_anonymous_bind = true
   
       eof
       if options.advanced?  


### PR DESCRIPTION
For our LDAP server, we cannot bind as admin (policy), but we can bind as a normal user to get info about ourself. This change adds support for it, using a config parameter that will not be noticed by any other users unless they want to use it.