### PR TITLE
Add a non-backward compatible option to support LDAP user binding

### DIFF
--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -28,8 +28,8 @@ module Devise
   mattr_accessor :ldap_check_attributes
   @@ldap_check_role_attribute = false
   
-  mattr_accessor :ldap_use_admin_to_bind
-  @@ldap_use_admin_to_bind = false
+  mattr_accessor :ldap_user_to_bind
+  @@ldap_user_to_bind = :none
   
   mattr_accessor :ldap_auth_username_builder
   @@ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "#{attribute}=#{login},#{ldap.base}" }

--- a/lib/devise_ldap_authenticatable/ldap/adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap/adapter.rb
@@ -29,9 +29,10 @@ module Devise
         set_ldap_param(login, :userpassword, Net::LDAP::Password.generate(:sha, new_password), current_password)
       end
 
-      def self.ldap_connect(login)
+      def self.ldap_connect(login, password = nil)
         options = {:login => login,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                   :password => password,
                    :bind_user => ::Devise.ldap_user_to_bind}
 
         resource = Devise::LDAP::Connection.new(options)
@@ -73,8 +74,13 @@ module Devise
         resource.delete_param(param)
       end
 
-      def self.get_ldap_param(login,param)
-        resource = self.ldap_connect(login)
+      def self.get_ldap_param(login,param, password = nil)
+        options = { :login => login,
+                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                    :password => password,
+                    :bind_user => ::Devise.ldap_user_to_bind }
+
+        resource = Devise::LDAP::Connection.new(options)
         resource.ldap_param_value(param)
       end
 

--- a/lib/devise_ldap_authenticatable/ldap/adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap/adapter.rb
@@ -9,7 +9,7 @@ module Devise
         options = {:login => login,
                    :password => password_plaintext,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :bind_user => ::Devise.ldap_user_to_bind}
 
         resource = Devise::LDAP::Connection.new(options)
         resource.authorized?
@@ -19,7 +19,7 @@ module Devise
         options = {:login => login,
                    :new_password => new_password,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :bind_user => ::Devise.ldap_user_to_bind}
 
         resource = Devise::LDAP::Connection.new(options)
         resource.change_password! if new_password.present?
@@ -32,7 +32,7 @@ module Devise
       def self.ldap_connect(login)
         options = {:login => login,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :bind_user => ::Devise.ldap_user_to_bind}
 
         resource = Devise::LDAP::Connection.new(options)
       end
@@ -56,7 +56,8 @@ module Devise
       def self.set_ldap_param(login, param, new_value, password = nil)
         options = { :login => login,
                     :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                    :password => password }
+                    :password => password,
+                    :bind_user => ::Devise.ldap_user_to_bind }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.set_param(param, new_value)
@@ -65,7 +66,8 @@ module Devise
       def self.delete_ldap_param(login, param, password = nil)
         options = { :login => login,
                     :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                    :password => password }
+                    :password => password,
+                    :bind_user => ::Devise.ldap_user_to_bind }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.delete_param(param)

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -32,7 +32,7 @@ module Devise
         elsif params[:bind_user] == :user
           # bind using authentication of the user
           DeviseLdapAuthenticatable::Logger.send("Binding as user")
-          @ldap.auth @login, @password
+          @ldap.auth ldap_config["ad_domain"] + '\\' + @login, @password
         end
       end
 

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -21,11 +21,19 @@ module Devise
         @required_groups = ldap_config["required_groups"]
         @required_attributes = ldap_config["require_attribute"]
 
-        @ldap.auth ldap_config["admin_user"], ldap_config["admin_password"] if params[:admin]
-
         @login = params[:login]
         @password = params[:password]
         @new_password = params[:new_password]
+
+        if params[:bind_user] == :admin
+          # bind as admin user from config
+          DeviseLdapAuthenticatable::Logger.send("Binding as admin")
+          @ldap.auth ldap_config["admin_user"], ldap_config["admin_password"]
+        elsif params[:bind_user] == :user
+          # bind using authentication of the user
+          DeviseLdapAuthenticatable::Logger.send("Binding as user")
+          @ldap.auth @login, @password
+        end
       end
 
       def delete_param(param)
@@ -211,7 +219,7 @@ module Devise
           operations = ops
         end
 
-        if ::Devise.ldap_use_admin_to_bind
+        if ::Devise.ldap_user_to_bind == :admin
           privileged_ldap = Connection.admin
         else
           authenticate!

--- a/lib/generators/devise_ldap_authenticatable/install_generator.rb
+++ b/lib/generators/devise_ldap_authenticatable/install_generator.rb
@@ -35,7 +35,7 @@ module DeviseLdapAuthenticatable
   # config.ldap_config = "\#{Rails.root}/config/ldap.yml"
   # config.ldap_check_group_membership = false
   # config.ldap_check_attributes = false
-  # config.ldap_use_admin_to_bind = false
+  # config.ldap_user_to_bind = :none
   # config.ldap_ad_group_check = false
   
       eof

--- a/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
+++ b/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
@@ -27,6 +27,7 @@ development:
   base: ou=people,dc=test,dc=com
   admin_user: cn=admin,dc=test,dc=com
   admin_password: admin_password
+  ad_domain: 
   ssl: false
   # <<: *AUTHORIZATIONS
 
@@ -37,6 +38,7 @@ test:
   base: ou=people,dc=test,dc=com
   admin_user: cn=admin,dc=test,dc=com
   admin_password: admin_password
+  ad_domain: 
   ssl: simple_tls
   # <<: *AUTHORIZATIONS
 
@@ -47,5 +49,6 @@ production:
   base: ou=people,dc=test,dc=com
   admin_user: cn=admin,dc=test,dc=com
   admin_password: admin_password
+  ad_domain: 
   ssl: start_tls
   # <<: *AUTHORIZATIONS


### PR DESCRIPTION
For our LDAP server, we cannot bind as admin (policy), but we can bind as a normal user to get info about ourself. This change adds support for it, using a modified config parameter, at the expense of all users needing to edit their config.