### PR TITLE
Devise Lockable compatibility

### DIFF
--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -87,13 +87,13 @@ module Devise
 
           resource = where(auth_key => auth_key_value).first
 
-          if (resource.blank? and ::Devise.ldap_create_user)
+          if resource.blank? && ::Devise.ldap_create_user
             resource = new
             resource[auth_key] = auth_key_value
             resource.password = attributes[:password]
           end
 
-          if resource && resource.new_record?
+          if resource && resource.new_record? && resource.valid_ldap_authentication?(attributes[:password])
             resource.ldap_before_save if resource.respond_to?(:ldap_before_save)
             resource.save!
           end

--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -4,7 +4,7 @@ module Devise
   module Strategies
     class LdapAuthenticatable < Authenticatable
       def authenticate!
-        resource = mapping.to.find_for_ldap_authentication(authentication_hash)
+        resource = mapping.to.find_for_ldap_authentication(authentication_hash.merge(password: password))
         
         if resource && validate(resource) { resource.valid_ldap_authentication?(password) }
           success!(resource)

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -66,7 +66,7 @@ describe 'Users' do
         assert(User.all.blank?, "There shouldn't be any users in the database")
       end
 
-      it "should don't create user in the database" do
+      it "should not create user in the database" do
         @user = User.find_for_ldap_authentication(:email => "example.user@test.com", :password => "secret")
         assert(User.all.blank?)
       end


### PR DESCRIPTION
Because #authenticate_with_ldap returns nil when the authentication fails, Devise's Lockable module wouldn't work: the failed_attempts attribute is incremented when the resource is validated, which can't happen to a nil resource, obviously.

I changed #authenticate_with_ldap to #find_for_ldap_authentication. This matches the pattern in database_authenticatable, and returns a resource regardless of whether the user is authenticated or not (but only creates it locally when the correct password is supplied).
# validate gets passed a block to do the password check for actual login, just like database_authenticatable. And, of course, lockable works.
