### PR TITLE
added a custom update operations modifier proc

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ These parameters will be added to `config/initializers/devise.rb` when you pass 
 * `ldap_auth_password_build` _(default: `Proc.new() {|new_password| Net::LDAP::Password.generate(:sha, new_password) }`)_
   * Optionally you can define a proc to create custom password encrption when user reset password
 
+* `ldap_update_operations_builder` _(default: `@@ldap_update_operations_builder = Proc.new() {|operations, options| operations }`)_
+  * Optionally you can define a proc to add/ additional custom update operations when user reset password
+  * `operations` is an array of LDAP operations, e.g. `[[:update, 'key', 'value']]`
+
+  Example, `config.ldap_update_operations_builder = Proc.new() {|operations, options| operations << [:replace, 'custom_attr_name', Time.now.to_s] }`
+
 Troubleshooting
 --------------
 **Using a "username" instead of an "email":** The field that is used for logins is the first key that's configured in the `config/devise.rb` file under `config.authentication_keys`, which by default is email. For help changing this, please see the [Railscast](http://railscasts.com/episodes/210-customizing-devise) that goes through how to customize Devise.

--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -38,6 +38,9 @@ module Devise
   mattr_accessor :ldap_auth_password_builder
   @@ldap_auth_password_builder = Proc.new() {|new_password| Net::LDAP::Password.generate(:sha, new_password) }
 
+  mattr_accessor :ldap_update_operations_builder
+  @@ldap_update_operations_builder = Proc.new() {|operations, options| [] }
+
   mattr_accessor :ldap_ad_group_check
   @@ldap_ad_group_check = false
 end

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -211,11 +211,17 @@ module Devise
           operations = ops
         end
 
+        additional_operations = ::Devise.ldap_update_operations_builder.call(operations, ops)
+
         if ::Devise.ldap_use_admin_to_bind
           privileged_ldap = Connection.admin
         else
           authenticate!
           privileged_ldap = self.ldap
+        end
+
+        unless additional_operations.size.zero?
+          privileged_ldap.modify(:dn => dn, :operations => additional_operations)
         end
 
         DeviseLdapAuthenticatable::Logger.send("Modifying user #{dn}")

--- a/lib/devise_ldap_authenticatable/version.rb
+++ b/lib/devise_ldap_authenticatable/version.rb
@@ -1,3 +1,3 @@
 module DeviseLdapAuthenticatable
-  VERSION = "0.8.3".freeze
+  VERSION = "0.8.4".freeze
 end


### PR DESCRIPTION
This proc allows update operations can be configured and inspected. This is useful when:
- Custom attributes needs to be modified, deleted, replaced outside the devise logic.
- Additional operations can be done in initialization configuration. This is better than let custom logic implemented in other places that would require to create separate ldap connection.
- Updated documentation
- Updated version number
