### PR TITLE
removed hidden char `\273' that was the reason of SyntaxError under jruby

### DIFF
--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -1,4 +1,4 @@
-﻿require 'devise_ldap_authenticatable/strategy'
+require 'devise_ldap_authenticatable/strategy'
 
 module Devise
   module Models


### PR DESCRIPTION
Example of SyntaxError:
SyntaxError: /Users/admin/.rvm/gems/jruby-head@torquebox/bundler/gems/devise_ldap_authenticatable-6a44c6b8cefd/lib/devise_ldap_authenticatable/model.rb:1: Invalid char `\273' ('»') in expressionï»¿require 'devise_ldap_authenticatable/strategy'
