### PR TITLE
Add an after_ldap_authentication callback

### DIFF
--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -72,6 +72,10 @@ module Devise
       # def ldap_before_save
       # end
 
+      # Called after a successful LDAP authentication
+      def after_ldap_authentication
+      end
+
 
       module ClassMethods
         # Find a user for ldap authentication.

--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -7,6 +7,7 @@ module Devise
         resource = mapping.to.find_for_ldap_authentication(authentication_hash.merge(password: password))
         
         if resource && validate(resource) { resource.valid_ldap_authentication?(password) }
+          resource.after_ldap_authentication
           success!(resource)
         else
           return fail(:invalid)


### PR DESCRIPTION
This adds a `after_ldap_authentication` callback similar to the [after_database_authentication](http://rubydoc.info/github/plataformatec/devise/master/Devise/Models/DatabaseAuthenticatable#after_database_authentication-instance_method) callback in `DatabaseAuthenticatable`.
