### PR TITLE
Allow passing a proc for ldap_config

### DIFF
--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -17,6 +17,8 @@ module Devise
   mattr_accessor :ldap_create_user
   @@ldap_create_user = false
   
+  # A path to YAML config file or a Proc that returns a
+  # configuration hash
   mattr_accessor :ldap_config
   # @@ldap_config = "#{Rails.root}/config/ldap.yml"
   

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -4,7 +4,11 @@ module Devise
       attr_reader :ldap, :login
 
       def initialize(params = {})
-        ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
+        if ::Devise.ldap_config.is_a?(Proc)
+          ldap_config = ::Devise.ldap_config.call
+        else
+          ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
+        end
         ldap_options = params
         ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
         ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -1,0 +1,14 @@
+require File.expand_path('../spec_helper', File.dirname(__FILE__))
+
+describe 'Connection' do
+  it 'accepts a proc for ldap_config' do
+    ::Devise.ldap_config = Proc.new() {{
+      'host' => 'localhost',
+      'port' => 3389,
+      'base' => 'ou=testbase,dc=test,dc=com',
+      'attribute' => 'cn',
+    }}
+    connection = Devise::LDAP::Connection.new()
+    expect(connection.ldap.base).to eq('ou=testbase,dc=test,dc=com')
+  end
+end


### PR DESCRIPTION
This allows providing a proc that returns a configuration hash to the ldap_config attribute.  This makes it possible to store LDAP configuration in a database or some other mechanism.

Existing functionality (loading from `ldap.yml`) remains unchanged.

For example:

``` ruby
Devise.setup do |config|
  # Load configuration from database
  config.ldap_config = Proc.new() { MyCoolORM::Config.ldap_config }
end
```
