### PR TITLE
Clarifying the 'Querying LDAP' section in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,10 @@ Querying LDAP
 -------------
 Given that `ldap_create_user` is set to true and you are authenticating with username, you can query an LDAP server for other attributes.
 
-in your user model:
+in your user model you have to simply define `ldap_before_save` method:
 
-    before_save :get_ldap_email
-
-    def get_ldap_email
-      self.email = Devise::LDAP::Adapter.get_ldap_param(self.username,"mail")
+    def ldap_before_save
+      self.email = Devise::LDAP::Adapter.get_ldap_param(self.username,"mail").first
     end
 
 Configuration


### PR DESCRIPTION
I have successfully configured Rails 4.2 and one ActiveDirectory based LDAP repository with this great software, thank you!

My authentication is `:username` based, so somehow I need to get the email address from the LDAP during the user creation. The `:before_save` callback of the model have not been called as it was suggested, so after I checked the source code I can see this `ldap_before_save` method invocation where the `resource.save!` called.
I have defined the method and everything is OK now, the successfully authenticated users are created in the user table.