### PR TITLE
Distinguish between invalid credentials and exclusion from database

### DIFF
--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -102,7 +102,7 @@ module Devise
             resource.password = attributes[:password]
           end
 
-          if resource && resource.new_record? && resource.valid_ldap_authentication?(attributes[:password]) && ::Devise.ldap_create_user
+          if ::Devise.ldap_create_user && resource.new_record? && resource.valid_ldap_authentication?(attributes[:password])
             resource.ldap_before_save if resource.respond_to?(:ldap_before_save)
             resource.save!
           end

--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -92,17 +92,17 @@ module Devise
           return nil unless attributes[auth_key].present?
 
           auth_key_value = (self.case_insensitive_keys || []).include?(auth_key) ? attributes[auth_key].downcase : attributes[auth_key]
-	  auth_key_value = (self.strip_whitespace_keys || []).include?(auth_key) ? auth_key_value.strip : auth_key_value
+      	  auth_key_value = (self.strip_whitespace_keys || []).include?(auth_key) ? auth_key_value.strip : auth_key_value
 
           resource = where(auth_key => auth_key_value).first
 
-          if resource.blank? && ::Devise.ldap_create_user
+          if resource.blank?
             resource = new
             resource[auth_key] = auth_key_value
             resource.password = attributes[:password]
           end
 
-          if resource && resource.new_record? && resource.valid_ldap_authentication?(attributes[:password])
+          if resource && resource.new_record? && resource.valid_ldap_authentication?(attributes[:password]) && ::Devise.ldap_create_user
             resource.ldap_before_save if resource.respond_to?(:ldap_before_save)
             resource.save!
           end

--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -2,11 +2,16 @@ require 'devise/strategies/authenticatable'
 
 module Devise
   module Strategies
-    class LdapAuthenticatable < Authenticatable
+    class LdapAuthenticatable < Autheneticatable
+
+      # Tests whether the returned resource exists in the database and the
+      # credentials are valid.  If the resource is in the database and the credentials
+      # are valid, the user is authenticated.  Otherwise failure messages are returned 
+      # indicating whether the resource is not found in the database or the credentials
+      # are invalid.
       def authenticate!
         resource = mapping.to.find_for_ldap_authentication(authentication_hash.merge(password: password))
 
-        # resource exists in database
         if resource.persisted?
           if validate(resource) { resource.valid_ldap_authentication?(password) }
             remember_me(resource)
@@ -17,15 +22,12 @@ module Devise
           end
         end
 
-        # resource does not exist in database
         if resource.new_record?
-
           if validate(resource) { resource.valid_ldap_authentication?(password) }
             return fail(:not_found_in_database) # Valid credentials
           else
             return fail(:invalid) # Invalid credentials
           end
-          
         end
       end
     end

--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -6,12 +6,26 @@ module Devise
       def authenticate!
         resource = mapping.to.find_for_ldap_authentication(authentication_hash.merge(password: password))
 
-        if resource && validate(resource) { resource.valid_ldap_authentication?(password) }
-          remember_me(resource)
-          resource.after_ldap_authentication
-          success!(resource)
-        else
-          return fail(:invalid)
+        # resource exists in database
+        if resource.persisted?
+          if validate(resource) { resource.valid_ldap_authentication?(password) }
+            remember_me(resource)
+            resource.after_ldap_authentication
+            success!(resource)
+          else
+            return fail(:invalid) # Invalid credentials
+          end
+        end
+
+        # resource does not exist in database
+        if resource.new_record?
+
+          if validate(resource) { resource.valid_ldap_authentication?(password) }
+            return fail(:not_found_in_database) # Valid credentials
+          else
+            return fail(:invalid) # Invalid credentials
+          end
+          
         end
       end
     end

--- a/spec/rails_app/config/locales/devise.en.yml
+++ b/spec/rails_app/config/locales/devise.en.yml
@@ -17,6 +17,7 @@ en:
       unauthenticated: 'You need to sign in or sign up before continuing.'
       unconfirmed: 'You have to confirm your account before continuing.'
       locked: 'Your account is locked.'
+      not_found_in_database: "Your account is not present in this application's database."
       invalid: 'Invalid email or password.'
       invalid_token: 'Invalid authentication token.'
       timeout: 'Your session expired, please sign in again to continue.'

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -69,6 +69,7 @@ describe 'Users' do
       it "should not create user in the database" do
         @user = User.find_for_ldap_authentication(:email => "example.user@test.com", :password => "secret")
         assert(User.all.blank?)
+        assert(@user.new_record?)
       end
 
       describe "creating users is enabled" do
@@ -80,6 +81,7 @@ describe 'Users' do
           @user = User.find_for_ldap_authentication(:email => "example.user@test.com", :password => "secret")
           assert_equal(User.all.size, 1)
           User.all.collect(&:email).should include("example.user@test.com")
+          assert(@user.persisted?)
         end
 
         it "should not create a user in the database if the password is wrong_secret" do


### PR DESCRIPTION
This PR is intended to provide feedback via failure messages about the reason their login has failed.  With this PR request a user will be able to distinguish whether they have provided invalid credentials or do not exist in the application's database.  This functionality is especially useful when `Devise.ldap_create_user = false`.  Otherwise the user may be confused as to why her login is being rejected.  Fixes #191 