### PR TITLE
Constant typo and authenticate fix

### DIFF
--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -12,6 +12,8 @@ module Devise
       def authenticate!
         resource = mapping.to.find_for_ldap_authentication(authentication_hash.merge(password: password))
 
+        return fail(:invalid) unless resource
+
         if resource.persisted?
           if validate(resource) { resource.valid_ldap_authentication?(password) }
             remember_me(resource)

--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -2,11 +2,11 @@ require 'devise/strategies/authenticatable'
 
 module Devise
   module Strategies
-    class LdapAuthenticatable < Autheneticatable
+    class LdapAuthenticatable < Authenticatable
 
       # Tests whether the returned resource exists in the database and the
       # credentials are valid.  If the resource is in the database and the credentials
-      # are valid, the user is authenticated.  Otherwise failure messages are returned 
+      # are valid, the user is authenticated.  Otherwise failure messages are returned
       # indicating whether the resource is not found in the database or the credentials
       # are invalid.
       def authenticate!


### PR DESCRIPTION
Recent commit introduced typo in constant. Updated change also assumes find_for_ldap_authentication always returns a resource object but could return nil.

I tried to run the tests but got a few failures for old config variables I think.

Keep up the good work on this gem :)