### PR TITLE
Fix class name for Devise::Authenticatable

### DIFF
--- a/lib/devise_ldap_authenticatable/strategy.rb
+++ b/lib/devise_ldap_authenticatable/strategy.rb
@@ -2,7 +2,7 @@ require 'devise/strategies/authenticatable'
 
 module Devise
   module Strategies
-    class LdapAuthenticatable < Autheneticatable
+    class LdapAuthenticatable < Authenticatable
 
       # Tests whether the returned resource exists in the database and the
       # credentials are valid.  If the resource is in the database and the credentials


### PR DESCRIPTION
During last merged PR, the class name Devise::Authenticatable was misspelled thus breaking the whole gem.  This is a fix and needs to be merged ASAP.  Fixes #195