### PR TITLE
Revert "Use admin_as_user to authenticate admin role by user login param...

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 Devise LDAP Authenticatable
 ===========================
-
-Why this fork?
---------------
-This fork changes a few lines to allow the admin binding to be set to the user trying to log in.
-
 [![Gem Version](https://badge.fury.io/rb/devise_ldap_authenticatable.png)](http://badge.fury.io/rb/devise_ldap_authenticatable)
 [![Code Climate](https://codeclimate.com/github/cschiewek/devise_ldap_authenticatable.png)](https://codeclimate.com/github/cschiewek/devise_ldap_authenticatable)
 [![Dependency Status](https://gemnasium.com/cschiewek/devise_ldap_authenticatable.png)](https://gemnasium.com/cschiewek/devise_ldap_authenticatable)

--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -1,5 +1,6 @@
 # encoding: utf-8
 require 'devise'
+require 'net/ldap'
 
 require 'devise_ldap_authenticatable/exception'
 require 'devise_ldap_authenticatable/logger'
@@ -27,6 +28,9 @@ module Devise
   mattr_accessor :ldap_check_group_membership
   @@ldap_check_group_membership = false
   
+  mattr_accessor :ldap_check_group_membership_without_admin
+  @@ldap_check_group_membership_without_admin = false
+
   mattr_accessor :ldap_check_attributes
   @@ldap_check_role_attribute = false
   
@@ -35,6 +39,9 @@ module Devise
   
   mattr_accessor :ldap_auth_username_builder
   @@ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "#{attribute}=#{login},#{ldap.base}" }
+
+  mattr_accessor :ldap_auth_password_builder
+  @@ldap_auth_password_builder = Proc.new() {|new_password| Net::LDAP::Password.generate(:sha, new_password) }
 
   mattr_accessor :ldap_ad_group_check
   @@ldap_ad_group_check = false

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -24,11 +24,11 @@ module Devise
 
         @group_base = ldap_config["group_base"]
         @check_group_membership = ldap_config.has_key?("check_group_membership") ? ldap_config["check_group_membership"] : ::Devise.ldap_check_group_membership
+        @check_group_membership_without_admin = ldap_config.has_key?("check_group_membership_without_admin") ? ldap_config["check_group_membership_without_admin"] : ::Devise.ldap_check_group_membership_without_admin
         @required_groups = ldap_config["required_groups"]
         @required_attributes = ldap_config["require_attribute"]
 
         @ldap.auth ldap_config["admin_user"], ldap_config["admin_password"] if params[:admin]
-        @ldap.auth params[:login], params[:password] if ldap_config["admin_as_user"]
 
         @login = params[:login]
         @password = params[:password]
@@ -100,11 +100,11 @@ module Devise
       end
 
       def change_password!
-        update_ldap(:userpassword => Net::LDAP::Password.generate(:sha, @new_password))
+        update_ldap(:userPassword => ::Devise.ldap_auth_password_builder.call(@new_password))
       end
 
       def in_required_groups?
-        return true unless @check_group_membership
+        return true unless @check_group_membership || @check_group_membership_without_admin
 
         ## FIXME set errors here, the ldap.yml isn't set properly.
         return false if @required_groups.nil?
@@ -122,23 +122,29 @@ module Devise
       def in_group?(group_name, group_attribute = LDAP::DEFAULT_GROUP_UNIQUE_MEMBER_LIST_KEY)
         in_group = false
 
-        admin_ldap = Connection.admin
+        if @check_group_membership_without_admin
+          group_checking_ldap = @ldap
+        else
+          group_checking_ldap = Connection.admin
+        end
 
         unless ::Devise.ldap_ad_group_check
-          admin_ldap.search(:base => group_name, :scope => Net::LDAP::SearchScope_BaseObject) do |entry|
+          group_checking_ldap.search(:base => group_name, :scope => Net::LDAP::SearchScope_BaseObject) do |entry|
             if entry[group_attribute].include? dn
               in_group = true
+              DeviseLdapAuthenticatable::Logger.send("User #{dn} IS included in group: #{group_name}")
             end
           end
         else
           # AD optimization - extension will recursively check sub-groups with one query
           # "(memberof:1.2.840.113556.1.4.1941:=group_name)"
-          search_result = admin_ldap.search(:base => dn,
+          search_result = group_checking_ldap.search(:base => dn,
                             :filter => Net::LDAP::Filter.ex("memberof:1.2.840.113556.1.4.1941", group_name),
                             :scope => Net::LDAP::SearchScope_BaseObject)
           # Will return  the user entry if belongs to group otherwise nothing
           if search_result.length == 1 && search_result[0].dn.eql?(dn)
             in_group = true
+            DeviseLdapAuthenticatable::Logger.send("User #{dn} IS included in group: #{group_name}")
           end
         end
 


### PR DESCRIPTION
Reverts cschiewek/devise_ldap_authenticatable#165

#165 added an unwanted README change, did not updated the doc or the default config files (this broke tests, cf #201), and I havent managed to get it working (when using admin_as_user as intended, login and password are not set when opening a LDAP connection as an admin.

Without it, all works correctly using `ldap_check_group_membership_without_admin` and you get the expected behavior the user initially wanted.

A version bump after merging this would be a good idea as the gem is currently broken when you try to use the user connection as the admin one, as per the docs.
