### PR TITLE
required_attributes check: allow one or more of a list of values

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -157,7 +157,9 @@ module Devise
         user = find_ldap_user(admin_ldap)
 
         @required_attributes.each do |key,val|
-          unless user[key].include? val
+          
+          matching_attributes = user[key] & Array.wrap(val)
+          unless (matching_attributes).any?
             DeviseLdapAuthenticatable::Logger.send("User #{dn} did not match attribute #{key}:#{val}")
             return false
           end

--- a/spec/rails_app/config/ldap_with_erb.yml
+++ b/spec/rails_app/config/ldap_with_erb.yml
@@ -6,7 +6,9 @@ authorizations: &AUTHORIZATIONS
   required_groups:
     - cn=admins,<%= "ou=groups,#{@base}" %>
   require_attribute:
-    objectClass: inetOrgPerson
+    objectClass: 
+      - inetOrgPerson
+      - organizationalPerson
     authorizationRole: blogAdmin
     
 test: &TEST


### PR DESCRIPTION
Added support for array of attribute values. If user has one of the listed values, the check passes.

Use case:
  We want to allow users to authenticate if the are part of a particular division. 
  We want to support multiple divisions.

Usage:
  In ldap.yml, specify an array for a given attribute:

```
  require_attribute:
    division:
     - "Informatics RD&E"
     - 'Informatics'
```