### PR TITLE
[Security] Update net-ldap gem to 0.6.0 or higher

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For a screencast with an example application, please visit: [http://random-rails
 Prerequisites
 -------------
  * devise ~> 3.0.0 (which requires rails ~> 4.0)
- * net-ldap ~> 0.3.1
+ * net-ldap ~> 0.6.0
 
 Note: Rails 3.x / Devise 2.x has been moved to the 0.7 branch.  All 0.7.x gems will support Rails 3, where as 0.8.x will support Rails 4.
 

--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency('devise', '>= 3.4.1')
-  s.add_dependency('net-ldap', '>= 0.3.1', '< 0.6.0')
+  s.add_dependency('net-ldap', '>= 0.6.0', '<= 0.11')
 
   s.add_development_dependency('rake', '>= 0.9')
   s.add_development_dependency('rdoc', '>= 3')


### PR DESCRIPTION
Due to a security vuln in the library ([OSVDB-106108](http://osvdb.org/show/osvdb/106108)), builds that incorporate bundler-audit as a failure condition will, well, fail:

```
+ /usr/local/rvm/bin/rvm 2.0.0 do ./bin/bundle-audit update
Updating ruby-advisory-db ...
From https://github.com/rubysec/ruby-advisory-db
 * branch            master     -> FETCH_HEAD
Already up-to-date.
ruby-advisory-db: 145 advisories
+ /usr/local/rvm/bin/rvm 2.0.0 do ./bin/bundle-audit check
Name: net-ldap
Version: 0.5.1
Advisory: OSVDB-106108
Criticality: Low
URL: http://osvdb.org/show/osvdb/106108
Title: Net::LDAP for Ruby lib/net/ldap/password.rb SSHA Password Generation Weak Salt
Solution: upgrade to >= 0.6.0

Unpatched versions found!
Build step 'Execute shell' marked build as failure
```

Hopefully using net-ldap versions 0.6.0 through 0.11 work.