### PR TITLE
Add additional_ldap_filter suport.

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -27,6 +27,8 @@ module Devise
         @required_groups = ldap_config["required_groups"]
         @required_attributes = ldap_config["require_attribute"]
 
+        @additional_ldap_filter=ldap_config["additional_ldap_filter"]
+
         @ldap.auth ldap_config["admin_user"], ldap_config["admin_password"] if params[:admin]
         @ldap.auth params[:login], params[:password] if ldap_config["admin_as_user"]
 
@@ -185,6 +187,11 @@ module Devise
         @login_ldap_entry ||= begin
           DeviseLdapAuthenticatable::Logger.send("LDAP search for login: #{@attribute}=#{@login}")
           filter = Net::LDAP::Filter.eq(@attribute.to_s, @login.to_s)
+          if @additional_ldap_filter
+            DeviseLdapAuthenticatable::Logger.send("Adding Additional Filter #{@additional_ldap_filter}")
+            additional_filter = Net::LDAP::Filter.from_rfc2254(@additional_ldap_filter)
+            filter = filter & additional_filter
+          end
           ldap_entry = nil
           match_count = 0
           @ldap.search(:filter => filter) {|entry| ldap_entry = entry; match_count+=1}

--- a/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
+++ b/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
@@ -29,6 +29,7 @@ development:
   admin_user: cn=admin,dc=test,dc=com
   admin_password: admin_password
   ssl: false
+  additional_ldap_filter: "(&(objectClass=user)(sAMAccountType=805306368)(memberof:1.2.840.113556.1.4.1941:=CN=SomeActiveDirectoryGroup,OU=Groupies,cn=admin,dc=test,dc=com))"
   # <<: *AUTHORIZATIONS
 
 test:
@@ -39,6 +40,7 @@ test:
   admin_user: cn=admin,dc=test,dc=com
   admin_password: admin_password
   ssl: simple_tls
+  additional_ldap_filter: "(&(objectClass=user)(sAMAccountType=805306368)(memberof:1.2.840.113556.1.4.1941:=CN=SomeActiveDirectoryGroup,OU=Groupies,cn=admin,dc=test,dc=com))"
   # <<: *AUTHORIZATIONS
 
 production:
@@ -49,4 +51,5 @@ production:
   admin_user: cn=admin,dc=test,dc=com
   admin_password: admin_password
   ssl: start_tls
+  additional_ldap_filter: "(&(objectClass=user)(sAMAccountType=805306368)(memberof:1.2.840.113556.1.4.1941:=CN=SomeActiveDirectoryGroup,OU=Groupies,cn=admin,dc=test,dc=com))"
   # <<: *AUTHORIZATIONS


### PR DESCRIPTION
I found myself having to filter out certain users during the initial
user lookup in LDAP. 
This is because for some attributes like "mail" we
had duplicate user entries in our directory of over 30k Users.

This commit adds the capability to add a RFC2254 formatted String as an
optional additional filter.
This is joined using (&) to the default filter constructed.
