### PR TITLE
Feature/require attributes presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ In initializer  `config/initializers/devise.rb` :
   * When set to true, the user trying to login will be checked to make sure they are in all of groups specified in the ldap.yml file.
 * `ldap_check_attributes` _(default: false)_
   * When set to true, the user trying to login will be checked to make sure they have all of the attributes in the ldap.yml file.
+* `ldap_check_attributes_presence` _(default: false)_
+  * When set to true, the user trying to login will be checked against all `require_attribute_presence` attributes in the ldap.yml file, either present _(attr: true)_,or not present _(attr: false)_.
 * `ldap_use_admin_to_bind` _(default: false)_
   * When set to true, the admin user will be used to bind to the LDAP server during authentication.
 * `ldap_check_group_membership_without_admin` _(default: false)_

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ To start hacking on `devise_ldap_authentication`, clone the github repository, s
     # in a separate console or backgrounded
     ./spec/ldap/run-server
 
-    bundle exec rake db:migrate # first time only
+    RAILS_ENV=test bundle exec rake db:migrate # first time only
     bundle exec rake spec
 
 References

--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -18,16 +18,16 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
-  s.add_dependency('devise', '>= 3.4.1')
-  s.add_dependency('net-ldap', '>= 0.6.0', '<= 0.11')
+  s.add_dependency 'devise', '>= 3.4.1'
+  s.add_dependency 'net-ldap', '~> 0.12'
 
-  s.add_development_dependency('rake', '>= 0.9')
-  s.add_development_dependency('rdoc', '>= 3')
-  s.add_development_dependency('rails', '>= 4.0')
-  s.add_development_dependency('sqlite3')
-  s.add_development_dependency('factory_girl_rails', '~> 1.0')
-  s.add_development_dependency('factory_girl', '~> 2.0')
-  s.add_development_dependency('rspec-rails')
+  s.add_development_dependency 'rake', '>= 0.9'
+  s.add_development_dependency 'rdoc', '>= 3'
+  s.add_development_dependency 'rails', '>= 4.0'
+  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'factory_girl_rails', '~> 1.0'
+  s.add_development_dependency 'factory_girl', '~> 2.0'
+  s.add_development_dependency 'rspec-rails'
 
   %w{database_cleaner capybara launchy}.each do |dep|
     s.add_development_dependency(dep)

--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -11,28 +11,31 @@ module Devise
   # Allow logging
   mattr_accessor :ldap_logger
   @@ldap_logger = true
-  
+
   # Add valid users to database
   mattr_accessor :ldap_create_user
   @@ldap_create_user = false
-  
+
   # A path to YAML config file or a Proc that returns a
   # configuration hash
   mattr_accessor :ldap_config
   # @@ldap_config = "#{Rails.root}/config/ldap.yml"
-  
+
   mattr_accessor :ldap_update_password
   @@ldap_update_password = true
-  
+
   mattr_accessor :ldap_check_group_membership
   @@ldap_check_group_membership = false
-  
+
   mattr_accessor :ldap_check_attributes
   @@ldap_check_role_attribute = false
-  
+
+  mattr_accessor :ldap_check_attributes_presence
+  @@ldap_check_attributes_presence = false
+
   mattr_accessor :ldap_use_admin_to_bind
   @@ldap_use_admin_to_bind = false
-  
+
   mattr_accessor :ldap_auth_username_builder
   @@ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "#{attribute}=#{login},#{ldap.base}" }
 

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -156,9 +156,7 @@ module Devise
       def has_required_attribute?
         return true unless ::Devise.ldap_check_attributes
 
-        admin_ldap = Connection.admin
-
-        user = find_ldap_user(admin_ldap)
+        user = search_for_login
 
         @required_attributes.each do |key,val|
           unless user[key].include? val
@@ -173,9 +171,7 @@ module Devise
       def has_required_attribute_presence?
         return true unless ::Devise.ldap_check_attributes_presence
 
-        admin_ldap = Connection.admin
-
-        user = find_ldap_user(admin_ldap)
+        user = search_for_login
 
         @required_attributes_presence.each do |key,val|
           if val && !user.attribute_names.include?(key.to_sym)

--- a/lib/generators/devise_ldap_authenticatable/install_generator.rb
+++ b/lib/generators/devise_ldap_authenticatable/install_generator.rb
@@ -13,7 +13,7 @@ module DeviseLdapAuthenticatable
     end
 
     def create_default_devise_settings
-      inject_into_file "config/initializers/devise.rb", default_devise_settings, :after => "Devise.setup do |config|\n"   
+      inject_into_file "config/initializers/devise.rb", default_devise_settings, :after => "Devise.setup do |config|\n"
     end
 
     def update_user_model
@@ -28,7 +28,7 @@ module DeviseLdapAuthenticatable
 
     def default_devise_settings
       settings = <<-eof
-  # ==> LDAP Configuration 
+  # ==> LDAP Configuration
   # config.ldap_logger = true
   # config.ldap_create_user = false
   # config.ldap_update_password = true
@@ -36,12 +36,13 @@ module DeviseLdapAuthenticatable
   # config.ldap_check_group_membership = false
   # config.ldap_check_group_membership_without_admin = false
   # config.ldap_check_attributes = false
+  # config.ldap_check_attributes_presence = false
   # config.ldap_use_admin_to_bind = false
   # config.ldap_ad_group_check = false
 
       eof
-      if options.advanced?  
-        settings << <<-eof  
+      if options.advanced?
+        settings << <<-eof
   # ==> Advanced LDAP Configuration
   # config.ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "\#{attribute}=\#{login},\#{ldap.base}" }
 

--- a/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
+++ b/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
@@ -18,6 +18,12 @@ authorizations: &AUTHORIZATIONS
   require_attribute:
     objectClass: inetOrgPerson
     authorizationRole: postsAdmin
+  ## Requires config.ldap_check_attributes_presence in devise.rb to be true
+  ## Can have multiple attributes set to true or false to check presence, all must match all to be authorized
+  require_attribute_presence:
+    mail: true
+    telephoneNumber: true
+    serviceAccount: false
 
 ## Environment
 

--- a/spec/rails_app/config/ldap.yml
+++ b/spec/rails_app/config/ldap.yml
@@ -7,7 +7,9 @@ authorizations: &AUTHORIZATIONS
   require_attribute:
     objectClass: inetOrgPerson
     authorizationRole: blogAdmin
-    
+  require_attribute_presence:
+    mail: true
+
 test: &TEST
   host: localhost
   port: 3389
@@ -17,6 +19,6 @@ test: &TEST
   admin_password: secret
   ssl: false
   <<: *AUTHORIZATIONS
-  
+
 development:
   <<: *TEST

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -50,6 +50,7 @@ def default_devise_settings!
   ::Devise.ldap_config = "#{Rails.root}/config/#{"ssl_" if ENV["LDAP_SSL"]}ldap.yml"
   ::Devise.ldap_check_group_membership = false
   ::Devise.ldap_check_attributes = false
+  ::Devise.ldap_check_attributes_presence = false
   ::Devise.ldap_auth_username_builder = Proc.new() {|attribute, login, ldap| "#{attribute}=#{login},#{ldap.base}" }
   ::Devise.authentication_keys = [:email]
 end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -142,25 +142,25 @@ describe 'Users' do
         should_not_be_validated @user, "secret"
       end
     end
-    
+
     describe "check group membership" do
       before do
         @admin = Factory.create(:admin)
         @user = Factory.create(:user)
       end
-      
+
       it "should return true for admin being in the admins group" do
         assert_equal true, @admin.in_ldap_group?('cn=admins,ou=groups,dc=test,dc=com')
       end
-      
+
       it "should return false for admin being in the admins group using the 'foobar' group attribute" do
         assert_equal false, @admin.in_ldap_group?('cn=admins,ou=groups,dc=test,dc=com', 'foobar')
       end
-      
+
       it "should return true for user being in the users group" do
         assert_equal true, @user.in_ldap_group?('cn=users,ou=groups,dc=test,dc=com')
-      end   
-      
+      end
+
       it "should return false for user being in the admins group" do
         assert_equal false, @user.in_ldap_group?('cn=admins,ou=groups,dc=test,dc=com')
       end
@@ -214,6 +214,26 @@ describe 'Users' do
 
       it "should user should not be allowed in" do
         should_not_be_validated @user, "secret"
+      end
+    end
+
+    describe "use attribute presence for authorization" do
+      before do
+        @admin = Factory.create(:admin)
+        @user = Factory.create(:user)
+        ::Devise.ldap_check_attributes_presence = true
+      end
+
+      after do
+        ::Devise.ldap_check_attributes_presence = false
+      end
+
+      it "should admin should not be allowed in" do
+        should_not_be_validated @admin, "admin_secret"
+      end
+
+      it "should user should be allowed in" do
+        should_be_validated @user, "secret"
       end
     end
 


### PR DESCRIPTION
Howdy,
I had a requirement where we needed to only log in users who had certain attributes on their LDAP entry, not necessarily certain values for those attributes.  The attributes are boolean so that they could be required or not required to be present.