### PR TITLE
Check for valid, but expired credentials

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap/adapter.rb
@@ -15,6 +15,16 @@ module Devise
         resource.authorized?
       end
 
+      def self.expired_valid_credentials?(login, password_plaintext)
+        options = {:login => login,
+                   :password => password_plaintext,
+                   :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                   :admin => ::Devise.ldap_use_admin_to_bind}
+
+        resource = Devise::LDAP::Connection.new(options)
+        resource.expired_valid_credentials?
+      end
+
       def self.update_password(login, new_password)
         options = {:login => login,
                    :new_password => new_password,
@@ -34,7 +44,7 @@ module Devise
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
                    :admin => ::Devise.ldap_use_admin_to_bind}
 
-        resource = Devise::LDAP::Connection.new(options)
+        Devise::LDAP::Connection.new(options)
       end
 
       def self.valid_login?(login)
@@ -54,18 +64,18 @@ module Devise
       end
 
       def self.set_ldap_param(login, param, new_value, password = nil)
-        options = { :login => login,
-                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                    :password => password }
+        options = {:login => login,
+                   :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                   :password => password }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.set_param(param, new_value)
       end
 
       def self.delete_ldap_param(login, param, password = nil)
-        options = { :login => login,
-                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                    :password => password }
+        options = {:login => login,
+                   :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
+                   :password => password }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.delete_param(param)
@@ -79,9 +89,6 @@ module Devise
       def self.get_ldap_entry(login)
         self.ldap_connect(login).search_for_login
       end
-
     end
-
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,6 @@ ENV["RAILS_ENV"] = "test"
 
 require File.expand_path("rails_app/config/environment.rb",  File.dirname(__FILE__))
 require 'rspec/rails'
-require 'rspec/autorun'
 require 'factory_girl' # not sure why this is not already required
 
 # Rails 4.1 and RSpec are a bit on different pages on who should run migrations

--- a/spec/unit/adapter_spec.rb
+++ b/spec/unit/adapter_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+describe Devise::LDAP::Adapter do
+  describe '#expired_valid_credentials?' do
+    before do
+      ::Devise.ldap_use_admin_to_bind = true
+      expect_any_instance_of(Devise::LDAP::Connection).to receive(:expired_valid_credentials?)
+    end
+
+    it 'can bind as the admin user' do
+      expect(Devise::LDAP::Connection).to receive(:new)
+        .with(hash_including(
+                  :login => 'test.user@test.com',
+                  :password => 'pass',
+                  :ldap_auth_username_builder => kind_of(Proc),
+                  :admin => true)).and_call_original
+
+      Devise::LDAP::Adapter.expired_valid_credentials?('test.user@test.com', 'pass')
+    end
+  end
+end

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -11,4 +11,93 @@ describe 'Connection' do
     connection = Devise::LDAP::Connection.new()
     expect(connection.ldap.base).to eq('ou=testbase,dc=test,dc=com')
   end
+
+  class TestOpResult
+    attr_accessor :error_message
+  end
+
+  describe '#expired_valid_credentials?' do
+    let(:conn) { double(Net::LDAP).as_null_object }
+    let(:error) { }
+    let(:is_authed) { false }
+    before do
+      expect(Net::LDAP).to receive(:new).and_return(conn)
+      allow(conn).to receive(:get_operation_result).and_return(TestOpResult.new.tap{|r| r.error_message = error})
+      allow_any_instance_of(Devise::LDAP::Connection).to receive(:authenticated?).and_return(is_authed)
+      allow_any_instance_of(Devise::LDAP::Connection).to receive(:dn).and_return('any dn')
+      expect(DeviseLdapAuthenticatable::Logger).to receive(:send).with('Authorizing user any dn')
+    end
+    subject do
+      Devise::LDAP::Connection.new.expired_valid_credentials?
+    end
+
+    context do
+      let(:error) { 'THIS PART CAN BE ANYTHING AcceptSecurityContext error, data 773 SO CAN THIS' }
+      it 'is true when expired credential error is returned and not already authenticated' do
+        expect(subject).to be true
+      end
+    end
+
+    context do
+      it 'is false when expired credential error is not returned and not already authenticated' do
+        expect(subject).to be false
+      end
+    end
+
+    context do
+      let(:is_authed) { true }
+      it 'is false when expired credential error is not returned and already authenticated' do
+        expect(subject).to be false
+      end
+    end
+  end
+
+  describe '#authorized?' do
+    let(:conn) { double(Net::LDAP).as_null_object }
+    let(:error) { }
+    let(:log_message) { }
+    let(:is_authed) { false }
+    before do
+      expect(Net::LDAP).to receive(:new).and_return(conn)
+      allow(conn).to receive(:get_operation_result).and_return(TestOpResult.new.tap{|r| r.error_message = error})
+      allow_any_instance_of(Devise::LDAP::Connection).to receive(:authenticated?).and_return(is_authed)
+      allow_any_instance_of(Devise::LDAP::Connection).to receive(:dn).and_return('any dn')
+      expect(DeviseLdapAuthenticatable::Logger).to receive(:send).with('Authorizing user any dn')
+    end
+    subject do
+      Devise::LDAP::Connection.new.authorized?
+    end
+    context do
+      before { expect(DeviseLdapAuthenticatable::Logger).to receive(:send).with(log_message) }
+
+      context do
+        let(:error) { 'THIS PART CAN BE ANYTHING AcceptSecurityContext error, data 52e SO CAN THIS' }
+        let(:log_message) { 'Not authorized because of invalid credentials.' }
+        it 'is false when credential error is returned' do
+          expect(subject).to be false
+        end
+      end
+      context do
+        let(:error) { 'THIS PART CAN BE ANYTHING AcceptSecurityContext error, data 773 SO CAN THIS' }
+        let(:log_message) { 'Not authorized because of expired credentials.' }
+        it 'is false when expired error is returned' do
+          expect(subject).to be false
+        end
+      end
+      context do
+        let(:error) { 'any error' }
+        let(:log_message) { 'Not authorized because not authenticated.' }
+        it 'is false when any other error is returned' do
+          expect(subject).to be false
+        end
+      end
+    end
+
+    context do
+      let(:is_authed) { true }
+      it 'is true when already authenticated' do
+        expect(subject).to be true
+      end
+    end
+  end
 end

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -16,7 +16,7 @@ describe 'Users' do
       reset_ldap_server!
     end
 
-    describe "look up and ldap user" do
+    describe "look up an ldap user" do
       it "should return true for a user that does exist in LDAP" do
         assert_equal true, ::Devise::LDAP::Adapter.valid_login?('example.user@test.com')
       end
@@ -48,7 +48,7 @@ describe 'Users' do
         should_be_validated @user, "secret"
         @user.password = "changed"
         @user.change_password!("secret")
-        should_be_validated @user, "changed", "password was not changed properly on the LDAP sevrer"
+        should_be_validated @user, "changed", "password was not changed properly on the LDAP server"
       end
 
       it "should not allow to change password if setting is false" do
@@ -249,6 +249,19 @@ describe 'Users' do
       end
     end
 
+    describe 'check password expiration' do
+      before { allow_any_instance_of(Devise::LDAP::Connection).to receive(:authenticated?).and_return(false) }
+
+      it 'should return false for a user that has a fresh password' do
+        allow_any_instance_of(Devise::LDAP::Connection).to receive(:last_message_expired_credentials?).and_return(false)
+        assert_equal false, ::Devise::LDAP::Adapter.expired_valid_credentials?('example.user@test.com','secret')
+      end
+
+      it 'should return true for a user that has an expired password' do
+        allow_any_instance_of(Devise::LDAP::Connection).to receive(:last_message_expired_credentials?).and_return(true)
+        assert_equal true, ::Devise::LDAP::Adapter.expired_valid_credentials?('example.user@test.com','secret')
+      end
+    end
   end
 
   describe "use uid for login" do

--- a/spec/unit/user_spec.rb
+++ b/spec/unit/user_spec.rb
@@ -80,7 +80,7 @@ describe 'Users' do
         it "should create a user in the database" do
           @user = User.find_for_ldap_authentication(:email => "example.user@test.com", :password => "secret")
           assert_equal(User.all.size, 1)
-          User.all.collect(&:email).should include("example.user@test.com")
+          expect(User.all.collect(&:email)).to include("example.user@test.com")
           assert(@user.persisted?)
         end
 
@@ -116,7 +116,7 @@ describe 'Users' do
           ::Devise.case_insensitive_keys = [:email]
 
           @user = User.find_for_ldap_authentication(:email => "EXAMPLE.user@test.com", :password => "secret")
-          User.all.collect(&:email).should include("example.user@test.com")
+          expect(User.all.collect(&:email)).to include("example.user@test.com")
         end
       end
 
@@ -135,7 +135,7 @@ describe 'Users' do
       end
 
       it "should admin should have the proper groups set" do
-        @admin.ldap_groups.should include('cn=admins,ou=groups,dc=test,dc=com')
+        expect(@admin.ldap_groups).to include('cn=admins,ou=groups,dc=test,dc=com')
       end
 
       it "should user should not be allowed in" do
@@ -279,7 +279,7 @@ describe 'Users' do
       it "should create a user in the database" do
         @user = User.find_for_ldap_authentication(:uid => "example_user", :password => "secret")
         assert_equal(User.all.size, 1)
-        User.all.collect(&:uid).should include("example_user")
+        expect(User.all.collect(&:uid)).to include("example_user")
       end
 
       it "should call ldap_before_save hooks" do


### PR DESCRIPTION
AD provides the ability to set a user account as having expired credentials with the property of `pwdLastSet`. If this is set to `0`, for example, the user will be forced to change their password the next time they login. In order to detect this with Devise, there needed to be a way of inspecting the error message that was returned from AD when the user was attempting authentication. 

Previously, just a yes/no was returned, but that was not granular enough for the "force change on next login" flow. If a user had this flag set, they would simply receive a "you're not authenticated" message, even though their credentials were correct. With this PR, a user can be authenticated and, subsequently, checked for stale credentials.

There is an additional commit that I included to clean up some deprecation warnings and formatting.
