### PR TITLE
Allow a connection timeout to be set

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -11,6 +11,7 @@ module Devise
         end
         ldap_options = params
         ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
+        ldap_options[:connect_timeout] = ldap_config["connect_timeout"] if ldap_config["connect_timeout"]
         ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
 
         @ldap = Net::LDAP.new(ldap_options)


### PR DESCRIPTION
Ruby's Net::LDAP supports a connect_timeout option for setting the socket connection timeout when connecting to LDAP servers. Support this.