### PR TITLE
Allow tls_options hash to be passed to Net::LDAP

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -10,8 +10,14 @@ module Devise
           ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
         end
         ldap_options = params
-        ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
-        ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
+                
+        if ldap_config["ssl"].is_a?(::Hash)
+          ldap_options[:encryption] = ldap_config["ssl"].symbolize_keys
+        else if ldap_config["ssl"] === true
+          ldap_options[:encryption] = :simple_tls
+        else if ldap_config["ssl"]
+          ldap_options[:encryption] = ldap_config["ssl"].to_sym
+        end
 
         @ldap = Net::LDAP.new(ldap_options)
         @ldap.host = ldap_config["host"]


### PR DESCRIPTION
Net::LDAP::Connection supports a hash under the `:encryption` key in the options hash. The hash may have two keys, `:method` and `:tls_options` just a single symbol value (`:simple_tls` or `:start_tls`).

This would then allow you to add options like the following to your ldap.yml:

```yaml
development:
  host: localhost
  port: 636
  ssl:
    method: simple_tls
    tls_options:
      verify_mode: VERIFY_NONE
      session_cache_mode: SESSION_CACHE_CLIENT
```