### PR TITLE
Updated def in_group

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -139,7 +139,7 @@ module Devise
           if group.is_a?(Array)
             return false unless in_group?(group[1], group[0])
           else
-            return false unless in_group?(group)
+            return false unless in_group?(group, @group_membership_attribute)
           end
         end
         return true


### PR DESCRIPTION
To use the "group membership attribute" (@group_membership_attribute) you need to put in the call to the function in_group. If not, it would use the default value of it 's definition (LDAP::DEFAULT_GROUP_UNIQUE_MEMBER_LIST_KEY).