### PR TITLE
Allow ldap_config to set Net::LDAP encryption options

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -10,8 +10,11 @@ module Devise
           ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
         end
         ldap_options = params
+
+        # Allow `ssl: true` shorthand in YAML, but enable more control with `encryption`
         ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
         ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
+        ldap_options[:encryption] = ldap_config["encryption"] if ldap_config["encryption"]
 
         @ldap = Net::LDAP.new(ldap_options)
         @ldap.host = ldap_config["host"]

--- a/spec/rails_app/db/migrate/20100708120448_devise_create_users.rb
+++ b/spec/rails_app/db/migrate/20100708120448_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration
+class DeviseCreateUsers < ActiveRecord::Migration[5.1]
   def self.up
     create_table(:users) do |t|
       ## Database authenticatable

--- a/spec/rails_app/db/schema.rb
+++ b/spec/rails_app/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,23 +12,22 @@
 
 ActiveRecord::Schema.define(version: 20100708120448) do
 
-  create_table "users", force: true do |t|
-    t.string   "email",                  default: "", null: false
-    t.string   "encrypted_password",     default: "", null: false
-    t.string   "reset_password_token"
+  create_table "users", force: :cascade do |t|
+    t.string "email", default: "", null: false
+    t.string "encrypted_password", default: "", null: false
+    t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
-    t.integer  "sign_in_count",          default: 0
+    t.integer "sign_in_count", default: 0
     t.datetime "current_sign_in_at"
     t.datetime "last_sign_in_at"
-    t.string   "current_sign_in_ip"
-    t.string   "last_sign_in_ip"
-    t.string   "uid"
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.string "current_sign_in_ip"
+    t.string "last_sign_in_ip"
+    t.string "uid"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_users_on_email", unique: true
+    t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
-
-  add_index "users", ["email"], name: "index_users_on_email", unique: true
-  add_index "users", ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
 
 end

--- a/spec/unit/connection_spec.rb
+++ b/spec/unit/connection_spec.rb
@@ -12,6 +12,24 @@ describe 'Connection' do
     expect(connection.ldap.base).to eq('ou=testbase,dc=test,dc=com')
   end
 
+  it 'allows encryption options to be set in ldap_config' do
+    ::Devise.ldap_config = Proc.new() {{
+      'host' => 'localhost',
+      'port' => 3389,
+      'base' => 'ou=testbase,dc=test,dc=com',
+      'attribute' => 'cn',
+      'encryption' => {
+        :method => :simple_tls,
+        :tls_options => OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+      }
+    }}
+    connection = Devise::LDAP::Connection.new()
+    expect(connection.ldap.instance_variable_get(:@encryption)).to eq({
+      :method => :simple_tls,
+      :tls_options => OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+    })
+  end
+
   class TestOpResult
     attr_accessor :error_message
   end


### PR DESCRIPTION
Hello!  This PR allows callers to set the `Net::LDAP` encryption configuration.  I want to pass some additional options that I can't from the outside right now.

To do this, the PR updates `connection.rb` to allow passing any encryption options to `Net::LDAP`, rather than just the simple `ssl: true` options that are currently enabled.  It's backwards compatible and doesn't change the way existing config values are read.

This contains one unrelated change, since following the [development guide](https://github.com/cschiewek/devise_ldap_authenticatable#development-guide) in the README ran into migration errors.  Those are addressed here.  By running `RAILS_ENV=test bundle exec rake db:migrate` it also created changes to the `schema.rb` file.  It seemed good to include these here so other new developers can contribute, but if you want me to exclude I can push another commit doing that.

Thanks!