### PR TITLE
README: Drop badge for defunct service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Devise LDAP Authenticatable
 ===========================
 [![Gem Version](https://badge.fury.io/rb/devise_ldap_authenticatable.png)](http://badge.fury.io/rb/devise_ldap_authenticatable)
 [![Code Climate](https://codeclimate.com/github/cschiewek/devise_ldap_authenticatable.png)](https://codeclimate.com/github/cschiewek/devise_ldap_authenticatable)
-[![Dependency Status](https://gemnasium.com/cschiewek/devise_ldap_authenticatable.png)](https://gemnasium.com/cschiewek/devise_ldap_authenticatable)
 
 Devise LDAP Authenticatable is a LDAP based authentication strategy for the [Devise](http://github.com/plataformatec/devise) authentication framework.
 


### PR DESCRIPTION
This PR removes the Gemnasium badge, since that service is no longer operational.