### PR TITLE
Allowing override of encryption while attempting to maintain original…

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -10,8 +10,15 @@ module Devise
           ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
         end
         ldap_options = params
-        ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
-        ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
+
+        if ldap_config.has_key?('encryption')
+          ldap_options[:encryption] = ldap_config['encryption'].with_indifferent_access
+        elsif ldap_config["ssl"] === true
+          ldap_options[:encryption] = {
+            method: :simple_tls,
+            tls_options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS
+          }
+        end
 
         @ldap = Net::LDAP.new(ldap_options)
         @ldap.host = ldap_config["host"]


### PR DESCRIPTION
Small update to cater for the encryption parameter used when initializing Net::LDAP.

Current implementation of this gem will set the encryption value to :simple_tls if the ssl flag is set to true in ldap.yml which is not compatible according to the documentation:

https://www.rubydoc.info/github/ruby-ldap/ruby-net-ldap/Net%2FLDAP:initialize  

> :encryption => specifies the encryption to be used in communicating with the LDAP server. The value must be a Hash containing additional parameters, which consists of two keys:
> method: - :simple_tls or :start_tls
> tls_options: - Hash of options for that method

This PR allows updates the default value to accommodate TLS with certificate verification if ssl is set to true, but further allows override of the encryption parameter opening to flexiblilty for specific requirements of tls options.

This is particularly a pain point for me because my specific requirement is to NOT verify the server certificate.

With the changes introduced here I can specify within ldap.yml the following:

```
encryption:
    method: :simple_tls
    tls_options: 
      verify_mode: 0 # VERIFY_NONE
```