### PR TITLE
Fix LDAP encryption settings translation for net-ldap 0.16

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -14,7 +14,14 @@ module Devise
         # Allow `ssl: true` shorthand in YAML, but enable more control with `encryption`
         ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
         ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
-        ldap_options[:encryption] = ldap_config["encryption"] if ldap_config["encryption"]
+
+        if ldap_config["encryption"]
+          ldap_options[:encryption] = ldap_config["encryption"].deep_symbolize_keys
+          ldap_options[:encryption][:method] = ldap_options[:encryption][:method].to_sym if ldap_options[:encryption][:method]
+          if ldap_options[:encryption][:tls_options]
+            ldap_options[:encryption][:tls_options][:verify_mode] = OpenSSL::SSL::VERIFY_NONE if ldap_options[:encryption][:tls_options][:verify_mode] = "OpenSSL::SSL::VERIFY_NONE"
+          end
+        end
 
         @ldap = Net::LDAP.new(ldap_options)
         @ldap.host = ldap_config["host"]


### PR DESCRIPTION
I tried to configure LDAP to ignore the certificate validation in development mode when using LDAPS and a test server and used the following keys in my `ldap.yml` to set the encryption:

```
  encryption:
    method: simple_tls
    tls_options:
      verify_mode: OpenSSL::SSL::VERIFY_NONE
```

However, because the YAML file is interpreted with string values, it was not compatible with `net-ldap` which always expects symbols. As a fix I updated `ldap/connection.rb` to translate the config to symbols if the encryption key is present. I am aware that this only takes this one use case into account and would love to extend or generalise it, if someone proposes a better approach or knows what's necessary to make the gem officially support `net-ldap 0.16`. But I thought that it might already be helpful to some in this version. 