### PR TITLE
Use ruby 1.9 hash syntax and edit HTTP status code

### DIFF
--- a/lib/generators/devise_ldap_authenticatable/install_generator.rb
+++ b/lib/generators/devise_ldap_authenticatable/install_generator.rb
@@ -55,7 +55,7 @@ module DeviseLdapAuthenticatable
     def rescue_from_exception
       <<-eof
   rescue_from DeviseLdapAuthenticatable::LdapException do |exception|
-    render :text => exception, :status => 500
+    render text: exception, status: :internal_server_error
   end
       eof
     end


### PR DESCRIPTION
- Remove hash rockets
- Prefer `:internal_server_error` over `500` to define HTTP status code. (convention:Rails/HttpStatus)