### PR TITLE
Check if user is present in any of multiple possible group names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ test/rails_app/tmp
 pkg/*
 *.gem
 .vscode
+spec/rails_app/tmp

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -140,7 +140,6 @@ module Devise
 
         for group in @required_groups
           if group.is_a?(Array)
-            return false unless in_group?(group[1], group[0])
             return false unless group[1..-1].select(&:present?).any? { |g| in_group?(g, group[0]) }
           else
             return false unless in_group?(group)

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -141,6 +141,7 @@ module Devise
         for group in @required_groups
           if group.is_a?(Array)
             return false unless in_group?(group[1], group[0])
+            return false unless group[1..-1].select(&:present?).any? { |g| in_group?(g, group[0]) }
           else
             return false unless in_group?(group)
           end

--- a/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
+++ b/lib/generators/devise_ldap_authenticatable/templates/ldap.yml
@@ -13,6 +13,8 @@ authorizations: &AUTHORIZATIONS
     - cn=users,ou=groups,dc=test,dc=com
     # If an array is given, the first element will be the attribute to check against, the second the group name
     - ["moreMembers", "cn=users,ou=groups,dc=test,dc=com"]
+    # If multiple group names are given, verification will be satisfied if at least one of them matches the check
+    - ["moreMembers", "cn=mods,ou=groups,dc=test,dc=com", "cn=admins,ou=groups,dc=test,dc=com"]
   ## Requires config.ldap_check_attributes in devise.rb to be true
   ## Can have multiple attributes and values, must match all to be authorized
   require_attribute:


### PR DESCRIPTION
Hello nice folk 😄 

This PR is an attempt at implementing the feature request in #149, which happens to be also something that my team at @simplybusiness needs as well.

In order to not introducing any breaking changes, I have made possible to add additional elements to any array member of `required_groups` so that we can introduce exclusive operations in without touching any of the inclusive logic operation that are done among all the members of `required_groups`.

I hope this make sense to you. I haven't seen any tests covering the `#in_required_groups?` part of [`#authorized?`](https://github.com/cschiewek/devise_ldap_authenticatable/blob/default/lib/devise_ldap_authenticatable/ldap/connection.rb#L99) - I will try to add something [here](https://github.com/cschiewek/devise_ldap_authenticatable/blob/default/spec/unit/connection_spec.rb#L73) as soon as I am able to run the whole tests suite in my local machine.

Thank you.