### PR TITLE
Adding method required by Devise Token Auth.

### DIFF
--- a/lib/devise_ldap_authenticatable/model.rb
+++ b/lib/devise_ldap_authenticatable/model.rb
@@ -43,6 +43,10 @@ module Devise
         end
       end
 
+      def valid_password?(password)
+        valid_ldap_authentication?(password)
+      end
+
       # Checks if a resource is valid upon authentication.
       def valid_ldap_authentication?(password)
         Devise::LDAP::Adapter.valid_credentials?(login_with, password)


### PR DESCRIPTION
Thank you very much for creating and maintaining this gem. I have just started using it for Active Directory integration and it is working very well.

My stack also includes Devise Token Auth and I needed to add "valid_password?" to the model in order to make the gems work together.

Using these gems together seems like it would be quite a common practice, so I thought I would make a pull request to add this method.