### PR TITLE
Drop unused gemspec directives

### DIFF
--- a/devise_ldap_authenticatable.gemspec
+++ b/devise_ldap_authenticatable.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
 
   s.add_dependency 'devise', '>= 3.4.1'


### PR DESCRIPTION
This gem exposes no executables and test_files is no longer used by RubyGems.org.