### PR TITLE
Add psych4 support

### DIFF
--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -7,7 +7,12 @@ module Devise
         if ::Devise.ldap_config.is_a?(Proc)
           ldap_config = ::Devise.ldap_config.call
         else
-          ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
+          source = ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result
+          begin
+            ldap_config = YAML.load(source, aliases: true)[Rails.env]
+          rescue ArgumentError
+            ldap_config = YAML.load(source)[Rails.env]
+          end
         end
         ldap_options = params
 


### PR DESCRIPTION
* Psych 4 does not load aliases unless `aliases: true` is provided as an argument
* Workaround taken from rails: https://github.com/rails/rails/commit/179d0a1f474ada02e0030ac3bd062fc653765dbe