### PR TITLE
support for connect_timeout parameter added

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ In initializer  `config/initializers/devise.rb` :
   * When set to true, the admin user will be used to bind to the LDAP server during authentication.
 * `ldap_check_group_membership_without_admin` _(default: false)_
   * When set to true, the group membership check is done with the user's own credentials rather than with admin credentials. Since these credentials are only available to the Devise user model during the login flow, the group check function will not work if a group check is performed when this option is true outside of the login flow (e.g., before particular actions).
+* `ldap_connect_timeout` _(default: `::Net::LDAP::Connection::DefaultConnectTimeout` = 5)_
+  * Used to set the connect timeout for server connection, see [Net::LDAP::Connection](https://www.rubydoc.info/github/ruby-ldap/ruby-net-ldap/Net/LDAP/Connection)
 
 Advanced Configuration
 ----------------------

--- a/lib/devise_ldap_authenticatable.rb
+++ b/lib/devise_ldap_authenticatable.rb
@@ -48,6 +48,9 @@ module Devise
 
   mattr_accessor :ldap_ad_group_check
   @@ldap_ad_group_check = false
+
+  mattr_accessor :ldap_connect_timeout
+  @@ldap_connect_timeout = ::Net::LDAP::Connection::DefaultConnectTimeout
 end
 
 # Add ldap_authenticatable strategy to defaults.

--- a/lib/devise_ldap_authenticatable/ldap/adapter.rb
+++ b/lib/devise_ldap_authenticatable/ldap/adapter.rb
@@ -9,7 +9,9 @@ module Devise
         options = {:login => login,
                    :password => password_plaintext,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :admin => ::Devise.ldap_use_admin_to_bind,
+                   :connect_timeout => Devise.ldap_connect_timeout
+        }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.authorized?
@@ -19,7 +21,9 @@ module Devise
         options = {:login => login,
                    :password => password_plaintext,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :admin => ::Devise.ldap_use_admin_to_bind,
+                   :connect_timeout => Devise.ldap_connect_timeout
+        }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.expired_valid_credentials?
@@ -29,7 +33,9 @@ module Devise
         options = {:login => login,
                    :new_password => new_password,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :admin => ::Devise.ldap_use_admin_to_bind,
+                   :connect_timeout => Devise.ldap_connect_timeout
+        }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.change_password! if new_password.present?
@@ -42,7 +48,9 @@ module Devise
       def self.ldap_connect(login)
         options = {:login => login,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :admin => ::Devise.ldap_use_admin_to_bind}
+                   :admin => ::Devise.ldap_use_admin_to_bind,
+                   :connect_timeout => Devise.ldap_connect_timeout
+        }
 
         Devise::LDAP::Connection.new(options)
       end
@@ -66,7 +74,9 @@ module Devise
       def self.set_ldap_param(login, param, new_value, password = nil)
         options = {:login => login,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :password => password }
+                   :password => password,
+                   :connect_timeout => Devise.ldap_connect_timeout
+        }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.set_param(param, new_value)
@@ -75,7 +85,9 @@ module Devise
       def self.delete_ldap_param(login, param, password = nil)
         options = {:login => login,
                    :ldap_auth_username_builder => ::Devise.ldap_auth_username_builder,
-                   :password => password }
+                   :password => password,
+                   :connect_timeout => Devise.ldap_connect_timeout
+        }
 
         resource = Devise::LDAP::Connection.new(options)
         resource.delete_param(param)

--- a/lib/devise_ldap_authenticatable/ldap/connection.rb
+++ b/lib/devise_ldap_authenticatable/ldap/connection.rb
@@ -7,7 +7,11 @@ module Devise
         if ::Devise.ldap_config.is_a?(Proc)
           ldap_config = ::Devise.ldap_config.call
         else
-          ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
+          begin
+            ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result)[Rails.env]
+          rescue Psych::AliasesNotEnabled
+            ldap_config = YAML.load(ERB.new(File.read(::Devise.ldap_config || "#{Rails.root}/config/ldap.yml")).result, aliases: true)[Rails.env]
+          end
         end
         ldap_options = params
 
@@ -15,7 +19,7 @@ module Devise
         ldap_config["ssl"] = :simple_tls if ldap_config["ssl"] === true
         ldap_options[:encryption] = ldap_config["ssl"].to_sym if ldap_config["ssl"]
         ldap_options[:encryption] = ldap_config["encryption"] if ldap_config["encryption"]
-
+        ldap_options[:connect_timeout] = ldap_config["connect_timeout"] if ldap_config["connect_timeout"]
         @ldap = Net::LDAP.new(ldap_options)
         @ldap.host = ldap_config["host"]
         @ldap.port = ldap_config["port"]


### PR DESCRIPTION
Hello,

this PR should add support for the `connect_timeout` parameter for Net::LDAP.
